### PR TITLE
feat(cli): add exec command to sandbox and run-image

### DIFF
--- a/monocore/lib/cli/args/monocore.rs
+++ b/monocore/lib/cli/args/monocore.rs
@@ -237,8 +237,12 @@ pub enum MonocoreSubcommand {
         args: Vec<String>,
 
         /// Run sandbox in the background
-        #[arg(long)]
+        #[arg(short, long)]
         detach: bool,
+
+        /// Execute a command within the sandbox
+        #[arg(short, long)]
+        exec: Option<String>,
     },
 
     /// Start a sandbox
@@ -265,7 +269,7 @@ pub enum MonocoreSubcommand {
         args: Vec<String>,
 
         /// Run sandbox in the background
-        #[arg(long)]
+        #[arg(short, long)]
         detach: bool,
     },
 
@@ -293,7 +297,7 @@ pub enum MonocoreSubcommand {
         args: Vec<String>,
 
         /// Run sandbox in the background
-        #[arg(long)]
+        #[arg(short, long)]
         detach: bool,
     },
 
@@ -336,6 +340,10 @@ pub enum MonocoreSubcommand {
         /// Working directory
         #[arg(long)]
         workdir: Option<Utf8UnixPathBuf>,
+
+        /// Execute a command within the sandbox
+        #[arg(short, long)]
+        exec: Option<String>,
     },
 
     /// Install a script from an image
@@ -392,13 +400,13 @@ pub enum MonocoreSubcommand {
     /// Start project sandboxes
     #[command(name = "up")]
     Up {
-        /// Target sandboxes
-        #[arg(short, long, default_value_t = true)]
-        sandbox: bool,
-
-        /// Target group
+        /// Project path
         #[arg(short, long)]
-        group: bool,
+        path: Option<PathBuf>,
+
+        /// Config path
+        #[arg(short, long)]
+        config: Option<String>,
 
         /// Names of components to start
         names: Vec<String>,
@@ -407,13 +415,13 @@ pub enum MonocoreSubcommand {
     /// Stop project sandboxes
     #[command(name = "down")]
     Down {
-        /// Target sandboxes
-        #[arg(short, long, default_value_t = true)]
-        sandbox: bool,
-
-        /// Target group
+        /// Project path
         #[arg(short, long)]
-        group: bool,
+        path: Option<PathBuf>,
+
+        /// Config path
+        #[arg(short, long)]
+        config: Option<String>,
 
         /// Names of components to stop
         names: Vec<String>,
@@ -497,20 +505,9 @@ pub enum MonocoreSubcommand {
         action: SelfAction,
     },
 
-    /// Deploy to cloud
-    #[command(name = "deploy")]
-    Deploy {
-        /// Deploy sandbox
-        #[arg(short, long)]
-        sandbox: bool,
-
-        /// Deploy group
-        #[arg(short, long)]
-        group: bool,
-
-        /// Name of component to deploy
-        name: Option<String>,
-    },
+    /// Manage remote sandboxes
+    #[command(name = "remote")]
+    Remote,
 
     /// Start a server for orchestrating sandboxes
     #[command(name = "server")]
@@ -519,14 +516,27 @@ pub enum MonocoreSubcommand {
         #[arg(long)]
         port: Option<u16>,
 
-        /// Daemon control
-        #[arg(long)]
-        daemon: Option<String>,
+        /// The subcommand to run
+        #[command(subcommand)]
+        subcommand: Option<ServerSubcommand>,
     },
 
     /// Version of monocore
     #[command(name = "version")]
     Version,
+}
+
+/// Subcommands for the server subcommand
+#[derive(Debug, Parser)]
+pub enum ServerSubcommand {
+    /// Start a remote sandbox
+    Up,
+
+    /// Stop a remote sandbox
+    Down,
+
+    /// List remote sandboxes
+    List,
 }
 
 /// Actions for the self subcommand

--- a/monocore/lib/error.rs
+++ b/monocore/lib/error.rs
@@ -275,7 +275,7 @@ pub enum MonocoreError {
     CidError(#[from] ipld::cid::Error),
 
     /// An error that occurred when a sandbox was not found in the configuration
-    #[error("sandbox not found in configuration: '{0}' at '{1}'")]
+    #[error("cannot find sandbox: '{0}' at '{1}'")]
     SandboxNotFoundInConfig(String, PathBuf),
 
     /// An error that occurs when an invalid log level is used.

--- a/monocore/lib/management/image.rs
+++ b/monocore/lib/management/image.rs
@@ -231,6 +231,7 @@ async fn check_image_layers(
             // Image exists, check if all layers are present
             match db::get_image_layers(pool, &image.to_string()).await {
                 Ok(layers) => {
+                    let mut found_layers = 0;
                     for (digest, _, _) in layers {
                         // Check if layer exists in the layers directory
                         let layer_path =
@@ -239,7 +240,16 @@ async fn check_image_layers(
                             tracing::warn!("layer {} not found in layers directory", digest);
                             return Ok(false);
                         }
+
+                        tracing::info!("layer {} found in layers directory", digest);
+                        found_layers += 1;
                     }
+
+                    if found_layers < 1 {
+                        tracing::warn!("no layers found for image {}", image);
+                        return Ok(false);
+                    }
+
                     Ok(true)
                 }
                 Err(e) => {

--- a/monocore/lib/management/mod.rs
+++ b/monocore/lib/management/mod.rs
@@ -23,3 +23,4 @@ pub mod menv;
 pub mod orchestra;
 pub mod rootfs;
 pub mod sandbox;
+pub mod models;

--- a/monocore/lib/management/models/mod.rs
+++ b/monocore/lib/management/models/mod.rs
@@ -1,0 +1,12 @@
+//! Models for Monocore management.
+//!
+//! This module contains the core data structures and types used throughout the Monocore
+//! management system.
+
+mod sandbox;
+
+//--------------------------------------------------------------------------------------------------
+// Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use sandbox::*;

--- a/monocore/lib/management/models/sandbox.rs
+++ b/monocore/lib/management/models/sandbox.rs
@@ -1,0 +1,36 @@
+use chrono::{DateTime, Utc};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// A sandbox is an active virtual machine that is managed by Monocore.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Sandbox {
+    /// The name of the sandbox.
+    pub name: String,
+
+    /// The Monocore configuration filename that defines the sandbox.
+    pub config_file: String,
+
+    /// The last modified date and time of the Monocore configuration file.
+    pub config_last_modified: DateTime<Utc>,
+
+    /// The status of the sandbox.
+    pub status: String,
+
+    /// The PID of the supervisor process for the sandbox.
+    pub supervisor_pid: u32,
+
+    /// The PID of the microVM process for the sandbox.
+    pub microvm_pid: u32,
+
+    /// The paths to the root filesystems for the sandbox.
+    pub rootfs_paths: String,
+
+    /// The ID of the group that the sandbox belongs to.
+    pub group_id: Option<u32>,
+
+    /// The IP address of the group that the sandbox belongs to.
+    pub group_ip: Option<String>,
+}

--- a/monocore/lib/oci/implementations/docker.rs
+++ b/monocore/lib/oci/implementations/docker.rs
@@ -479,7 +479,7 @@ impl OciRegistryPull for DockerRegistry {
             end.to_string()
         };
 
-        tracing::info!("fetching blob: {repository} {digest} {start}-{end}");
+        tracing::info!("fetching blob: {digest} {start}-{end}");
 
         let token = self
             .get_access_credentials(repository, DOCKER_AUTH_SERVICE, &["pull"])

--- a/monocore/lib/runtime/monitor.rs
+++ b/monocore/lib/runtime/monitor.rs
@@ -15,7 +15,7 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
 };
 
-use crate::{management::db, utils::MCRUN_LOG_PREFIX, vm::Rootfs, MonocoreResult};
+use crate::{management::{db, models::Sandbox}, utils::MCRUN_LOG_PREFIX, vm::Rootfs, MonocoreResult};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -144,13 +144,17 @@ impl ProcessMonitor for MicroVmMonitor {
         // Insert sandbox entry into database
         db::upsert_sandbox(
             &self.sandbox_db,
-            &self.sandbox_name,
-            &self.config_file,
-            &self.config_last_modified,
-            SANDBOX_STATUS_RUNNING,
-            self.supervisor_pid,
-            microvm_pid,
-            &rootfs_paths,
+            &Sandbox {
+                name: self.sandbox_name.clone(),
+                config_file: self.config_file.clone(),
+                config_last_modified: self.config_last_modified,
+                status: SANDBOX_STATUS_RUNNING.to_string(),
+                supervisor_pid: self.supervisor_pid,
+                microvm_pid,
+                rootfs_paths,
+                group_id: None,
+                group_ip: None,
+            },
         )
         .await
         .map_err(MonoutilsError::custom)?;


### PR DESCRIPTION
Add ability to execute arbitrary commands in sandboxes instead of only running predefined scripts. This adds a new --exec/-e flag to both the 'run' and 'tmp' commands.

- Add exec option to sandbox and run-image CLI commands
- Make script parameter optional, defaulting to DEFAULT_SCRIPT
- Add validation to prevent using both script and exec together
- Update sandbox run functions to handle exec commands
- Fix rootfs script patching to properly handle script updates
- Refactor sandbox DB operations to use new Sandbox model
