### PR TITLE
feat(cli): add log subcommand for viewing sandbox logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,6 +912,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "env_logger"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,6 +1847,7 @@ dependencies = [
  "typed-path",
  "uuid",
  "walkdir",
+ "which",
  "xattr",
 ]
 
@@ -4220,6 +4227,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4553,6 +4572,12 @@ checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/monocore/Cargo.toml
+++ b/monocore/Cargo.toml
@@ -81,6 +81,7 @@ ipldstore.workspace = true
 monofs.workspace = true
 async-recursion.workspace = true
 file-lock = "2.1.11"
+which = "7.0"
 
 [dev-dependencies]
 test-log.workspace = true

--- a/monocore/bin/monocore.rs
+++ b/monocore/bin/monocore.rs
@@ -1,11 +1,12 @@
 use clap::{error::ErrorKind, CommandFactory, Parser};
 use monocore::{
     cli::{AnsiStyles, MonocoreArgs, MonocoreSubcommand},
+    config,
     management::{image, menv, orchestra, sandbox},
     oci::Reference,
-    MonocoreResult,
+    MonocoreError, MonocoreResult,
 };
-
+use std::path::PathBuf;
 //--------------------------------------------------------------------------------------------------
 // Constants
 //--------------------------------------------------------------------------------------------------
@@ -13,6 +14,8 @@ use monocore::{
 const SANDBOX_SCRIPT_SEPARATOR: char = '~';
 const START_SCRIPT: &str = "start";
 const SHELL_SCRIPT: &str = "shell";
+const MONOCORE_ENV_DIR: &str = ".menv";
+const LOG_SUBDIR: &str = "log";
 
 //--------------------------------------------------------------------------------------------------
 // Functions: main
@@ -457,6 +460,55 @@ async fn main() -> MonocoreResult<()> {
             };
             orchestra::down(sandboxes, path, config.as_deref()).await?;
         }
+        Some(MonocoreSubcommand::Log {
+            sandbox,
+            sandbox_with_flag,
+            path,
+            config,
+            follow,
+            tail,
+        }) => {
+            let sandbox = match (sandbox, sandbox_with_flag) {
+                (Some(name), None) => name,
+                (None, Some(name)) => name,
+                (Some(_), Some(_)) => {
+                    MonocoreArgs::command()
+                        .override_usage(format!(
+                            "{} {} {} {}",
+                            "monocore".literal(),
+                            "log".literal(),
+                            "[OPTIONS]".placeholder(),
+                            "[SANDBOX]".placeholder(),
+                        ))
+                        .error(
+                            ErrorKind::ArgumentConflict,
+                            format!(
+                                "cannot specify sandbox both as a positional argument and with `{}` or `{}` flag",
+                                "--sandbox".placeholder(),
+                                "-s".placeholder()
+                            ),
+                        )
+                        .exit();
+                }
+                (None, None) => {
+                    MonocoreArgs::command()
+                        .override_usage(format!(
+                            "{} {} {} {}",
+                            "monocore".literal(),
+                            "log".literal(),
+                            "[OPTIONS]".placeholder(),
+                            "[SANDBOX]".placeholder(),
+                        ))
+                        .error(
+                            ErrorKind::MissingRequiredArgument,
+                            format!("must specify a sandbox or build to log."),
+                        )
+                        .exit();
+                }
+            };
+
+            handle_log_subcommand(&sandbox, path, config.as_deref(), follow, tail).await?;
+        }
         Some(_) => (), // TODO: implement other subcommands
         None => {
             MonocoreArgs::command().print_help()?;
@@ -477,4 +529,86 @@ fn parse_name_and_script(name_and_script: &str) -> (&str, Option<&str>) {
     };
 
     (name, script)
+}
+
+async fn handle_log_subcommand(
+    sandbox: &str,
+    project_dir: Option<PathBuf>,
+    config_file: Option<&str>,
+    follow: bool,
+    tail: Option<usize>,
+) -> MonocoreResult<()> {
+    // Check if tail command exists when follow mode is requested
+    if follow {
+        let tail_exists = which::which("tail").is_ok();
+        if !tail_exists {
+            MonocoreArgs::command()
+                .error(
+                    ErrorKind::InvalidValue,
+                    "'tail' command not found. Please install it to use the follow (-f) option.",
+                )
+                .exit();
+        }
+    }
+
+    // Load the configuration to get canonical paths
+    let (_, canonical_project_dir, config_file) =
+        config::load_config(project_dir, config_file).await?;
+
+    // Construct log file path: <project_dir>/.menv/log/<config>-<sandbox>.log
+    let log_path = canonical_project_dir
+        .join(MONOCORE_ENV_DIR)
+        .join(LOG_SUBDIR)
+        .join(format!("{}-{}.log", config_file, sandbox));
+
+    // Check if log file exists
+    if !log_path.exists() {
+        return Err(MonocoreError::LogNotFound(format!(
+            "Log file not found at {}",
+            log_path.display()
+        )));
+    }
+
+    if follow {
+        // For follow mode, use tokio::process::Command to run `tail -f`
+        let mut child = tokio::process::Command::new("tail")
+            .arg("-f")
+            .arg(&log_path)
+            .stdout(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()?;
+
+        // Wait for the tail process
+        let status = child.wait().await?;
+        if !status.success() {
+            return Err(MonocoreError::ProcessWaitError(format!(
+                "tail process exited with status: {}",
+                status
+            )));
+        }
+    } else {
+        // Read the file contents
+        let contents = tokio::fs::read_to_string(&log_path).await?;
+
+        // Split into lines
+        let lines: Vec<&str> = contents.lines().collect();
+
+        // If tail is specified, only show the last N lines
+        let lines_to_print = if let Some(n) = tail {
+            if n >= lines.len() {
+                &lines[..]
+            } else {
+                &lines[lines.len() - n..]
+            }
+        } else {
+            &lines[..]
+        };
+
+        // Print the lines
+        for line in lines_to_print {
+            println!("{}", line);
+        }
+    }
+
+    Ok(())
 }

--- a/monocore/lib/cli/args/monocore.rs
+++ b/monocore/lib/cli/args/monocore.rs
@@ -151,33 +151,29 @@ pub enum MonocoreSubcommand {
     /// Show logs of a running build, sandbox, or group
     #[command(name = "log")]
     Log {
-        /// Show sandbox logs
-        #[arg(short, long)]
-        sandbox: bool,
+        /// Specifies the sandbox
+        #[arg(name = "SANDBOX")]
+        sandbox: Option<String>,
 
-        /// Name of the component
-        #[arg(required = true)]
-        name: String,
+        /// Specifies the sandbox
+        #[arg(short, long = "sandbox", name = "SANDBOX\0")]
+        sandbox_with_flag: Option<String>,
+
+        /// Project path
+        #[arg(short, long)]
+        path: Option<PathBuf>,
+
+        /// Config path
+        #[arg(short, long)]
+        config: Option<String>,
 
         /// Follow the logs
-        #[arg(long)]
+        #[arg(short, long)]
         follow: bool,
 
-        /// Don't use a pager
-        #[arg(long)]
-        no_pager: bool,
-
         /// Number of lines to show from the end
-        #[arg(long)]
+        #[arg(short = 'n', long)]
         tail: Option<usize>,
-
-        /// Number of lines to show
-        #[arg(long)]
-        count: Option<usize>,
-
-        /// Log level
-        #[arg(short = 'L')]
-        level: Option<String>,
     },
 
     /// Show tree of layers that make up a build, sandbox, or group component

--- a/monocore/lib/management/db.rs
+++ b/monocore/lib/management/db.rs
@@ -12,8 +12,7 @@ use oci_spec::image::{ImageConfiguration, ImageIndex, ImageManifest, MediaType, 
 use sqlx::{migrate::Migrator, sqlite::SqlitePoolOptions, Pool, Row, Sqlite};
 use tokio::fs;
 
-use crate::management::models::Sandbox;
-use crate::{runtime::SANDBOX_STATUS_RUNNING, MonocoreResult};
+use crate::{management::models::Sandbox, runtime::SANDBOX_STATUS_RUNNING, MonocoreResult};
 
 //--------------------------------------------------------------------------------------------------
 // Constants

--- a/monocore/lib/management/mod.rs
+++ b/monocore/lib/management/mod.rs
@@ -20,7 +20,7 @@
 pub mod db;
 pub mod image;
 pub mod menv;
+pub mod models;
 pub mod orchestra;
 pub mod rootfs;
 pub mod sandbox;
-pub mod models;

--- a/monocore/lib/runtime/monitor.rs
+++ b/monocore/lib/runtime/monitor.rs
@@ -15,7 +15,12 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
 };
 
-use crate::{management::{db, models::Sandbox}, utils::MCRUN_LOG_PREFIX, vm::Rootfs, MonocoreResult};
+use crate::{
+    management::{db, models::Sandbox},
+    utils::MCRUN_LOG_PREFIX,
+    vm::Rootfs,
+    MonocoreResult,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Constants


### PR DESCRIPTION
- Add new `log` subcommand to view sandbox logs
- Support following logs with `-f/--follow` flag using `tail -f`
- Support viewing last N lines with `-n/--tail` option
