### PR TITLE
feat(network): add network scope configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ monocore/build/
 libkrunfw.*
 libkrun.*
 .menv/
-Sandboxfile
+Sandboxfile*

--- a/monocore/bin/mcrun.rs
+++ b/monocore/bin/mcrun.rs
@@ -23,6 +23,9 @@
 //!     --exec-path=/usr/bin/python3 \
 //!     --mapped-dirs=/host/path:/guest/path \
 //!     --port-maps=8080:80 \
+//!     --scope=group \
+//!     --ip=192.168.1.1 \
+//!     --subnet=192.168.1.0/24 \
 //!     --envs=KEY=VALUE \
 //!     -- -m http.server 8080
 //! ```
@@ -46,6 +49,9 @@
 //!     --port-maps=8080:80 \
 //!     --envs=KEY=VALUE \
 //!     --forward-output \
+//!     --scope=group \
+//!     --ip=192.168.1.1 \
+//!     --subnet=192.168.1.0/24 \
 //!     -- -m http.server 8080
 //! ```
 //!
@@ -93,6 +99,9 @@ async fn main() -> Result<()> {
             env,
             mapped_dir,
             port_map,
+            scope,
+            ip,
+            subnet,
             args,
         } => {
             tracing_subscriber::fmt::init();
@@ -159,6 +168,21 @@ async fn main() -> Result<()> {
                 builder = builder.port_map(port_map);
             }
 
+            // Set scope if provided
+            if let Some(scope) = scope {
+                builder = builder.scope(scope.parse()?);
+            }
+
+            // Set ip if provided
+            if let Some(ip) = ip {
+                builder = builder.ip(ip.parse()?);
+            }
+
+            // Set subnet if provided
+            if let Some(subnet) = subnet {
+                builder = builder.subnet(subnet.parse()?);
+            }
+
             // Set env if provided
             if !env.is_empty() {
                 builder = builder.env(env);
@@ -192,6 +216,9 @@ async fn main() -> Result<()> {
             env,
             mapped_dir,
             port_map,
+            scope,
+            ip,
+            subnet,
             args,
         } => {
             tracing_subscriber::fmt::init();
@@ -277,6 +304,21 @@ async fn main() -> Result<()> {
                 for port_map in port_map {
                     child_args.push(format!("--port-map={}", port_map));
                 }
+            }
+
+            // Set scope if provided
+            if let Some(scope) = scope {
+                child_args.push(format!("--scope={}", scope));
+            }
+
+            // Set ip if provided
+            if let Some(ip) = ip {
+                child_args.push(format!("--ip={}", ip));
+            }
+
+            // Set subnet if provided
+            if let Some(subnet) = subnet {
+                child_args.push(format!("--subnet={}", subnet));
             }
 
             // Set log level if provided

--- a/monocore/lib/cli/args/mcrun.rs
+++ b/monocore/lib/cli/args/mcrun.rs
@@ -63,6 +63,18 @@ pub enum McrunSubcommand {
         #[arg(long)]
         port_map: Vec<String>,
 
+        /// Network communication scope
+        #[arg(long)]
+        scope: Option<String>,
+
+        /// Assigned IP address
+        #[arg(long)]
+        ip: Option<String>,
+
+        /// Assigned subnet
+        #[arg(long)]
+        subnet: Option<String>,
+
         /// Additional arguments after `--`
         #[arg(last = true)]
         args: Vec<String>,
@@ -133,6 +145,18 @@ pub enum McrunSubcommand {
         /// Port mappings (host:guest format)
         #[arg(long)]
         port_map: Vec<String>,
+
+        /// Network communication scope
+        #[arg(long)]
+        scope: Option<String>,
+
+        /// Assigned IP address
+        #[arg(long)]
+        ip: Option<String>,
+
+        /// Assigned subnet
+        #[arg(long)]
+        subnet: Option<String>,
 
         /// Additional arguments after `--`
         #[arg(last = true)]

--- a/monocore/lib/config/monocore/builder.rs
+++ b/monocore/lib/config/monocore/builder.rs
@@ -8,7 +8,7 @@ use crate::{
     MonocoreResult,
 };
 
-use super::{Build, Group, Meta, Module, Monocore, Proxy, Sandbox, SandboxGroup, SandboxNetwork};
+use super::{Build, Group, Meta, Module, Monocore, Proxy, Sandbox, SandboxGroup, NetworkScope};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -53,7 +53,7 @@ pub struct MonocoreBuilder {
 /// - `scripts`: The scripts available in the sandbox
 /// - `imports`: The files to import
 /// - `exports`: The files to export
-/// - `network`: The network configuration for the sandbox
+/// - `scope`: The network scope for the sandbox
 /// - `proxy`: The proxy to use
 pub struct SandboxBuilder<I, S> {
     version: Option<Version>,
@@ -72,7 +72,7 @@ pub struct SandboxBuilder<I, S> {
     scripts: HashMap<String, String>,
     imports: HashMap<String, Utf8UnixPathBuf>,
     exports: HashMap<String, Utf8UnixPathBuf>,
-    network: Option<SandboxNetwork>,
+    scope: NetworkScope,
     proxy: Option<Proxy>,
 }
 
@@ -162,7 +162,7 @@ impl<I, S> SandboxBuilder<I, S> {
             scripts: self.scripts,
             imports: self.imports,
             exports: self.exports,
-            network: self.network,
+            scope: self.scope,
             proxy: self.proxy,
         }
     }
@@ -246,7 +246,7 @@ impl<I, S> SandboxBuilder<I, S> {
             scripts: self.scripts,
             imports: self.imports,
             exports: self.exports,
-            network: self.network,
+            scope: self.scope,
             proxy: self.proxy,
         }
     }
@@ -278,9 +278,9 @@ impl<I, S> SandboxBuilder<I, S> {
         self
     }
 
-    /// Sets the network for the sandbox
-    pub fn network(mut self, network: SandboxNetwork) -> SandboxBuilder<I, S> {
-        self.network = Some(network);
+    /// Sets the network scope for the sandbox
+    pub fn scope(mut self, scope: NetworkScope) -> SandboxBuilder<I, S> {
+        self.scope = scope;
         self
     }
 
@@ -311,7 +311,7 @@ impl SandboxBuilder<ReferenceOrPath, String> {
             scripts: self.scripts,
             imports: self.imports,
             exports: self.exports,
-            network: self.network,
+            scope: self.scope,
             proxy: self.proxy,
         }
     }
@@ -340,7 +340,7 @@ impl Default for SandboxBuilder<(), String> {
             scripts: HashMap::new(),
             imports: HashMap::new(),
             exports: HashMap::new(),
-            network: None,
+            scope: NetworkScope::Group,
             proxy: None,
         }
     }

--- a/monocore/lib/error.rs
+++ b/monocore/lib/error.rs
@@ -297,6 +297,10 @@ pub enum MonocoreError {
     /// An error that occurred running the sandbox server.
     #[error("sandbox server error: {0}")]
     SandboxServerError(String),
+
+    /// An error that occurred when an invalid network scope was used.
+    #[error("invalid network scope: {0}")]
+    InvalidNetworkScope(String),
 }
 
 /// An error that occurred when an invalid MicroVm configuration was used.

--- a/monocore/lib/management/sandbox.rs
+++ b/monocore/lib/management/sandbox.rs
@@ -183,6 +183,8 @@ pub async fn run(
         .arg(&config_last_modified.to_rfc3339())
         .arg("--sandbox-db-path")
         .arg(&sandbox_db_path)
+        .arg("--scope")
+        .arg(sandbox_config.get_scope().to_string())
         .arg("--exec-path")
         .arg(&exec_path);
 

--- a/monocore/lib/vm/ffi.rs
+++ b/monocore/lib/vm/ffi.rs
@@ -17,7 +17,6 @@ extern "C" {
     ///   - `3` - Info
     ///   - `4` - Debug
     ///   - `5` - Trace
-    #[allow(dead_code)]
     pub(crate) fn krun_set_log_level(level: u32) -> i32;
 
     /// Creates a configuration context.
@@ -197,6 +196,39 @@ extern "C" {
     /// supported as an API of libkrun (but you can still do port mapping using command line
     /// arguments of passt).
     pub(crate) fn krun_set_port_map(ctx_id: u32, c_port_map: *const *const c_char) -> i32;
+
+    /// Configures the static IP, subnet, and scope for the TSI network backend.
+    ///
+    /// ## Arguments
+    ///
+    /// * `ctx_id` - The configuration context ID.
+    /// * `c_ip` - An optional null-terminated string representing the guest's static IPv4 address.
+    /// * `c_subnet` - An optional null-terminated string representing the guest's subnet in CIDR notation (e.g., "192.168.1.0/24").
+    /// * `scope` - An integer specifying the scope (0-3):
+    ///   - `0` - None - Block all IP communication
+    ///   - `1` - Group - Allow within subnet (if specified; otherwise, block all like scope 0)
+    ///   - `2` - Public - Allow public IPs
+    ///   - `3` - Any - Allow any IP
+    ///
+    /// ## Returns
+    ///
+    /// Returns 0 on success or a negative error number on failure.
+    ///
+    /// ## Errors
+    ///
+    /// * `-EINVAL` - If scope value is > 3 or IP/subnet strings are invalid.
+    /// * `-ENOTSUP` - If the network mode is not TSI.
+    ///
+    /// ## Notes
+    ///
+    /// This function is only effective when the default TSI network backend is used (i.e., neither
+    /// `krun_set_passt_fd` nor `krun_set_gvproxy_path` has been called).
+    pub(crate) fn krun_set_tsi_scope(
+        ctx_id: u32,
+        c_ip: *const c_char,
+        c_subnet: *const c_char,
+        scope: u8,
+    ) -> i32;
 
     /// Enables and configures a virtio-gpu device.
     ///


### PR DESCRIPTION
Add network scope configuration to control sandbox network isolation levels:

- Replace SandboxNetwork with simpler NetworkScope enum (none/group/public/any)
- Add --scope, --ip, and --subnet CLI flags to mcrun command
- Update MicroVm builder and config to support network scope settings
- Add FFI bindings for krun_set_tsi_scope to configure network backend
- Update tests and documentation for new network scope features
- Removes SandboxNetwork and SandboxNetworkReach in favor of NetworkScope enum. Existing configs using network.reach will need to be updated to use the new scope field.

The network scope controls sandbox network isolation:
- none: No network communication between sandboxes
- group: Communication only within subnet (default)
- public: Communication with non-private addresses
- any: Unrestricted network access
